### PR TITLE
(GH-3) Run as user azp instead of root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,11 @@ LABEL MAINTAINER="BBT Software AG <devadmin@bbtsoftware.ch>"
 ENV DEBIAN_FRONTEND=noninteractive
 RUN echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
 
-RUN apt-get update && \
+RUN mkdir /azp && \
+    groupadd -r azp --gid=999 && \
+    useradd -r -g azp --uid=999 --home-dir=/azp --shell=/bin/bash azp && \
+    chown azp:azp /azp && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -20,3 +24,5 @@ WORKDIR /azp
 
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
+
+USER azp

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -26,7 +26,8 @@ rm -rf /azp/agent
 mkdir /azp/agent
 cd /azp/agent
 
-export AGENT_ALLOW_RUNASROOT="1"
+# Agent is running as user azp
+#export AGENT_ALLOW_RUNASROOT="1"
 
 cleanup() {
   if [ -e config.sh ]; then


### PR DESCRIPTION
It needs to run as non-root user.

Even if the [AGENT_ALLOW_RUNASROOT](https://github.com/bbtsoftware/docker-azure-devops-agent/blob/afbd58fd12bc2cbe334bf3f5e9ff636befd825c3/docker-entrypoint.sh#L29) is set as described [here](https://github.com/microsoft/azure-pipelines-agent/issues/1481) this won't work.

Fixes #3.