### PR TITLE
(GH-6) Add missing libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,11 @@ RUN apt-get update && \
         git \
         iputils-ping \
         libcurl3 \
-        libicu55
+        libicu55 \
+        libunwind8 \
+        netcat \ 
+        zip \
+        unzip
 
 WORKDIR /azp
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ These environment variables are supported:
 | AZP_POOL       | Agent pool name (default value: `Default`).                  |
 | AZP_WORK       | Work directory (default value: `_work`).                     |
 
+### Supported Azure Pipeline tasks
+
+The following Azure Pipeline tasks are supported:
+
+* Archive Files
+* Extract Files
+
 ## Samples
 
 ### docker-compose


### PR DESCRIPTION
Adds some missing libraries:

* libunwind8 (as seen in the error message)
* netcat (as seen [here](https://github.com/microsoft/vsts-agent-docker/blob/a5c2b5a670d6017853a4228dce3443e19a85bcb0/ubuntu/16.04/Dockerfile#L30))
* zip (as seen in note [here](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/docker?view=azure-devops#create-and-build-the-dockerfile))
* unzip (as seen in the note [here](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/docker?view=azure-devops#create-and-build-the-dockerfile))

Fixes #6.